### PR TITLE
Added {error, eisdir} as acceptable error when creating log-dir

### DIFF
--- a/src/audit_log_disk.erl
+++ b/src/audit_log_disk.erl
@@ -268,6 +268,8 @@ mkdir([Dir | Tail], Parent) ->
 	ok ->
 	    ok;
 	{error, eexist} ->
+	    ok;
+	{error, eisdir} ->
 	    ok
     end,
     mkdir(Tail, Path);


### PR DESCRIPTION
When attempting to create the log-directory and all its ancestors, file:make_dir("/") will fail with {error, eisdir} since "/" already exists. This patch handles that error.
